### PR TITLE
Add config :chatops_use_thread_replies

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ set :chatops_channel_id, 'your_channel_id'
 ...
 ```
 
+Config deploy success/failure notifications are posted as thread replies to the initial deploy start message.
+
+```ruby
+# config/deploy.rb
+set :chatops_use_thread_replies, true
+```
+
 ### Copyright
 
 ©rs-phunt

--- a/lib/capistrano/tasks/chatopsify.cap
+++ b/lib/capistrano/tasks/chatopsify.cap
@@ -6,7 +6,8 @@ namespace :chatops do
       if fetch(:chatops_notify_events).include? :started
         info 'Notifying ChatOps of deploy started'
         begin
-          Chatopsify::Co.call.process(Chatopsify::CoLib.msg_fmt(:starting))
+          response = Chatopsify::Co.call.process(Chatopsify::CoLib.msg_fmt(:starting))
+          set :chatops_root_id, response.dig('id') if fetch(:chatops_use_thread_replies)
         rescue StandardError => e
           info "ERROR notify_started: #{e}"
         end
@@ -23,7 +24,8 @@ namespace :chatops do
       if fetch(:chatops_notify_events).include? :finished
         info 'Notifying ChatOps of deploy finished'
         begin
-          Chatopsify::Co.call.process(Chatopsify::CoLib.msg_fmt(:success))
+          root_id = fetch(:chatops_use_thread_replies) ? fetch(:chatops_root_id) : nil
+          Chatopsify::Co.call.process(Chatopsify::CoLib.msg_fmt(:success), root_id)
         rescue StandardError => e
           info "ERROR notify_finished: #{e}"
         end
@@ -33,14 +35,15 @@ namespace :chatops do
   after 'deploy:finished', 'chatops:notify_finished'
   # before 'deploy:failed', 'chatops:notify_finished'
 
-  desc "Notify ChatOps Finished"
+  desc "Notify ChatOps Failed"
   task :notify_failed do
     set :chatops_time_finished, Time.now
     run_locally do
       if fetch(:chatops_notify_events).include? :failed
         info 'Notifying ChatOps of deploy failed'
         begin
-          Chatopsify::Co.call.process(Chatopsify::CoLib.msg_fmt(:failed))
+          root_id = fetch(:chatops_use_thread_replies) ? fetch(:chatops_root_id) : nil
+          Chatopsify::Co.call.process(Chatopsify::CoLib.msg_fmt(:failed), root_id)
         rescue StandardError => e
           info "ERROR notify_failed: #{e}"
         end
@@ -55,6 +58,7 @@ namespace :load do
     set :chatops_co_uri, nil
     set :chatops_api_key, nil
     set :chatops_channel_id, nil
+    set :chatops_use_thread_replies, false
 
     set :local_user, ->{ ENV["USER"] || ENV["LOGNAME"] || ENV["USERNAME"] || `hostname`.strip + '•' + `whoami`.strip || "default_user" }
     set :ip_address, ->{

--- a/lib/chatopsify/co.rb
+++ b/lib/chatopsify/co.rb
@@ -16,10 +16,10 @@ module Chatopsify
       new(*args, &block)
     end
 
-    def process(body = nil)
+    def process(body = nil, root_id = nil)
       body ||= Chatopsify::CoLib.msg_fmt
 
-      send_request(body)
+      send_request(body, root_id)
     rescue StandardError => e
       puts e.message
     end
@@ -51,19 +51,20 @@ module Chatopsify
       Chatopsify::CoSecurity.call(@api_key).decrypt_string
     end
 
-    def send_request(msg)
+    def send_request(msg, root_id)
       # puts "msg: #{msg}"
       uri = URI(@uri)
 
       req = Net::HTTP::Post.new(uri)
       req['authorization'] = "Bearer #{o_api_key}"
       req.content_type = 'application/json'
-      req.body = { channel_id: @channel_id, message: msg }.to_json
+      req.body = { channel_id: @channel_id, message: msg, root_id: root_id }.to_json
       res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
         http.request(req)
       end
 
       puts "Response: #{res.code} #{res.body}"
+      JSON.parse(res.body)
     end
 
     def send_delete_request(id = nil)


### PR DESCRIPTION
 - [x] Add config `:chatops_use_thread_replies` allow setting deploy success/failure notifications are posted as thread replies to the initial deploy start message.

<img width="801" height="463" alt="image" src="https://github.com/user-attachments/assets/14a0a3cc-8e6e-4b80-988f-4284fcb85f9b" />
