### PR TITLE
Add reusable Net::HTTP client with timeouts and reconnect handling

### DIFF
--- a/lib/chatopsify/co.rb
+++ b/lib/chatopsify/co.rb
@@ -6,6 +6,9 @@ require 'net/http'
 module Chatopsify
   # ChatOps services
   class Co
+    HTTP_OPEN_TIMEOUT = 5
+    HTTP_READ_TIMEOUT = 30
+
     def initialize(api_key = nil)
       @api_key    = api_key || load_api_key
       @channel_id = load_channel_id
@@ -51,6 +54,44 @@ module Chatopsify
       Chatopsify::CoSecurity.call(@api_key).decrypt_string
     end
 
+    def http_client(uri)
+      if @http_client&.active? && @http_uri&.host == uri.host &&
+         @http_uri&.port == uri.port && @http_uri&.scheme == uri.scheme
+        return @http_client
+      end
+
+      reset_http_client
+
+      client = Net::HTTP.new(uri.hostname, uri.port)
+      client.use_ssl = uri.scheme == 'https'
+      client.open_timeout = HTTP_OPEN_TIMEOUT
+      client.read_timeout = HTTP_READ_TIMEOUT
+      client.start
+
+      @http_client = client
+      @http_uri = uri
+      client
+    end
+
+    def with_http_client(uri)
+      client = http_client(uri)
+      yield client
+    rescue IOError, EOFError, Errno::ECONNRESET, Errno::EPIPE,
+           Net::OpenTimeout, Net::ReadTimeout, Timeout::Error
+      reset_http_client
+      client = http_client(uri)
+      yield client
+    end
+
+    def reset_http_client
+      @http_client.finish if @http_client&.active?
+    rescue IOError, EOFError
+      nil
+    ensure
+      @http_client = nil
+      @http_uri = nil
+    end
+
     def send_request(msg, root_id)
       # puts "msg: #{msg}"
       uri = URI(@uri)
@@ -59,9 +100,7 @@ module Chatopsify
       req['authorization'] = "Bearer #{o_api_key}"
       req.content_type = 'application/json'
       req.body = { channel_id: @channel_id, message: msg, root_id: root_id }.to_json
-      res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
-        http.request(req)
-      end
+      res = with_http_client(uri) { |http| http.request(req) }
 
       puts "Response: #{res.code} #{res.body}"
       JSON.parse(res.body)
@@ -73,7 +112,7 @@ module Chatopsify
 
       req = Net::HTTP::Delete.new(uri)
       req['authorization'] = "Bearer #{o_api_key}"
-      res = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
+      res = with_http_client(uri) do |http|
         puts "req: #{req}"
         http.request(req)
       end


### PR DESCRIPTION
### Motivation
- Reduce repeated `Net::HTTP.start` calls and improve reliability by reusing an HTTP connection and handling transient connection errors.
- Provide sensible timeouts and ensure `use_ssl` follows the request URI scheme.

### Description
- Add `HTTP_OPEN_TIMEOUT` and `HTTP_READ_TIMEOUT` constants and a helper `http_client(uri)` that builds and starts a `Net::HTTP` instance with `use_ssl` based on the URI and configured timeouts.
- Add `with_http_client(uri)` wrapper that yields the shared client and retries once after resetting the client on common connection errors.
- Add `reset_http_client` to safely finish and clear the cached client and associated URI.
- Update `send_request` and `send_delete_request` to use `with_http_client` (replacing direct `Net::HTTP.start` usage) so connections are reused and automatically reconnected on failure.

### Testing
- No automated tests were executed as part of this change.
- Basic sanity verified via static inspection of `lib/chatopsify/co.rb` to ensure new helpers are referenced by `send_request` and `send_delete_request`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985a1bf163883318a87755de5ee8cf3)